### PR TITLE
refactor(crashlytics): restrict recordNonFatalError context to typed constants

### DIFF
--- a/__tests__/crashlytics.test.ts
+++ b/__tests__/crashlytics.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@react-native-firebase/crashlytics";
 
 const {
+  CrashlyticsContext,
   CrashlyticsLog,
   applyCrashlyticsConsent,
   initCrashlytics,
@@ -100,8 +101,8 @@ describe("recordNonFatalError", () => {
 
   it("logs the context message before recording the error when context is provided", () => {
     const error = new Error("export failed");
-    recordNonFatalError(error, "handleExportBackup failed");
-    expect(log).toHaveBeenCalledWith(mockInstance, "handleExportBackup failed");
+    recordNonFatalError(error, CrashlyticsContext.HandleExportBackupFailed);
+    expect(log).toHaveBeenCalledWith(mockInstance, CrashlyticsContext.HandleExportBackupFailed);
     expect(recordError).toHaveBeenCalledWith(mockInstance, error);
   });
 
@@ -136,7 +137,7 @@ describe("silent failure guards", () => {
 
   it("recordNonFatalError with context does not throw when getCrashlytics throws", () => {
     expect(() =>
-      recordNonFatalError(new Error("boom"), "some context")
+      recordNonFatalError(new Error("boom"), CrashlyticsContext.HandleImportBackupFailed)
     ).not.toThrow();
   });
 });

--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -32,7 +32,7 @@ import {
   scheduleTestNotification,
 } from "@/utils/notifications";
 import { getCrashlytics, crash } from "@react-native-firebase/crashlytics";
-import { CrashlyticsLog, crashlyticsAvailable, logToCrashlytics, recordNonFatalError } from "@/utils/crashlytics";
+import { CrashlyticsContext, CrashlyticsLog, crashlyticsAvailable, logToCrashlytics, recordNonFatalError } from "@/utils/crashlytics";
 
 export default function SettingsScreen() {
   const router = useRouter();
@@ -149,7 +149,7 @@ export default function SettingsScreen() {
       logToCrashlytics(CrashlyticsLog.CsvExportSucceeded);
       setToast({ message: t("csvExported"), type: "success" });
     } catch (err) {
-      recordNonFatalError(err as Error, "handleExportCSV failed");
+      recordNonFatalError(err as Error, CrashlyticsContext.HandleExportCSVFailed);
       setToast({ message: t("backupImportFailed"), type: "error" });
     }
   }
@@ -160,7 +160,7 @@ export default function SettingsScreen() {
       logToCrashlytics(CrashlyticsLog.BackupExportSucceeded);
       setToast({ message: t("backupExported"), type: "success" });
     } catch (err) {
-      recordNonFatalError(err as Error, "handleExportBackup failed");
+      recordNonFatalError(err as Error, CrashlyticsContext.HandleExportBackupFailed);
       setToast({ message: t("backupImportFailed"), type: "error" });
     }
   }
@@ -184,7 +184,7 @@ export default function SettingsScreen() {
               setToast({ message: t("backupImported"), type: "success" });
             } catch (err) {
               if (err instanceof Error && err.message !== "cancelled") {
-                recordNonFatalError(err, "handleImportBackup failed");
+                recordNonFatalError(err, CrashlyticsContext.HandleImportBackupFailed);
                 setToast({ message: t("backupImportFailed"), type: "error" });
               }
             } finally {

--- a/utils/crashlytics.ts
+++ b/utils/crashlytics.ts
@@ -24,6 +24,16 @@ export function initCrashlytics(): void {
   }
 }
 
+/** Allowed context identifiers passed to recordNonFatalError. Add new entries here as needed. */
+export const CrashlyticsContext = {
+  HandleExportCSVFailed: "handleExportCSV failed",
+  HandleExportBackupFailed: "handleExportBackup failed",
+  HandleImportBackupFailed: "handleImportBackup failed",
+} as const;
+
+type CrashlyticsContextValue =
+  (typeof CrashlyticsContext)[keyof typeof CrashlyticsContext];
+
 /** Allowed breadcrumb messages for Crashlytics. Add new entries here as needed. */
 export const CrashlyticsLog = {
   ExpenseAdded: "Expense added",
@@ -60,7 +70,7 @@ export function applyCrashlyticsConsent(enabled: boolean) {
  * Record a non-fatal error — shows up in Crashlytics as a non-fatal issue
  * rather than a full crash, useful for caught errors you still want visibility on.
  */
-export function recordNonFatalError(error: Error, context?: string) {
+export function recordNonFatalError(error: Error, context?: CrashlyticsContextValue) {
   try {
     const instance = getCrashlytics();
     if (context) log(instance, context);


### PR DESCRIPTION
Adds `CrashlyticsContext` with allowed context identifiers and updates `recordNonFatalError` to accept `CrashlyticsContextValue` instead of a free-form string, preventing accidental transmission of user data via magic strings.

Closes #2

Generated with [Claude Code](https://claude.ai/code)