### PR TITLE
fix: handle cold-start notification deep-linking on Android

### DIFF
--- a/__mocks__/expo-notifications.ts
+++ b/__mocks__/expo-notifications.ts
@@ -32,3 +32,4 @@ export const setNotificationHandler = jest.fn();
 export const addNotificationResponseReceivedListener = jest
   .fn()
   .mockReturnValue({ remove: jest.fn() });
+export const getLastNotificationResponseAsync = jest.fn().mockResolvedValue(null);

--- a/__tests__/notificationNavigation.test.tsx
+++ b/__tests__/notificationNavigation.test.tsx
@@ -1,15 +1,24 @@
 /**
  * Tests for notification deep-linking in app/_layout.tsx.
  *
- * Verifies that tapping a notification cold-starts the app and routes to the
- * correct screen (getLastNotificationResponseAsync path, Android cold-start).
+ * Covers:
+ *  - Cold-start (getLastNotificationResponseAsync path, Android)
+ *  - Warm-start (addNotificationResponseReceivedListener path)
+ *  - Deduplication when both paths fire for the same notification
+ *  - Lock-enabled: navigation queued and fired after unlock
  */
 import React from "react";
-import { render, waitFor } from "@testing-library/react-native";
+import { act, render, waitFor } from "@testing-library/react-native";
 import * as Notifications from "expo-notifications";
 import { NOTIFICATION_IDS } from "@/utils/notifications";
 
 const mockPush = jest.fn();
+const mockUseBudget = jest.fn(() => ({
+  isLoaded: true,
+  state: { lockEnabled: false },
+  lockSuppressed: false,
+}));
+let mockOnUnlock: (() => void) | null = null;
 
 jest.mock("expo-router", () => {
   const StackScreen = () => null;
@@ -39,18 +48,21 @@ jest.mock("@expo-google-fonts/inter", () => ({
 }));
 
 jest.mock("@/context/BudgetContext", () => ({
-  useBudget: () => ({
-    isLoaded: true,
-    state: { lockEnabled: false },
-    lockSuppressed: false,
-  }),
+  useBudget: () => mockUseBudget(),
   BudgetProvider: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
 }));
 
 jest.mock("@/components/AppName", () => () => null);
-jest.mock("@/components/LockScreen", () => () => null);
+jest.mock(
+  "@/components/LockScreen",
+  () =>
+    ({ onUnlock }: { onUnlock: () => void }) => {
+      mockOnUnlock = onUnlock;
+      return null;
+    },
+);
 jest.mock("@/utils/crashlytics", () => ({ initCrashlytics: jest.fn() }));
 jest.mock("@/utils/lockTimer", () => ({
   shouldReLock: jest.fn().mockReturnValue(false),
@@ -81,6 +93,12 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockGetLast.mockResolvedValue(null);
   mockAddListener.mockReturnValue({ remove: jest.fn() });
+  mockUseBudget.mockReturnValue({
+    isLoaded: true,
+    state: { lockEnabled: false },
+    lockSuppressed: false,
+  });
+  mockOnUnlock = null;
 });
 
 describe("cold-start notification navigation", () => {
@@ -116,5 +134,82 @@ describe("cold-start notification navigation", () => {
     render(<RootLayout />);
     await waitFor(() => expect(mockGetLast).toHaveBeenCalled());
     expect(mockPush).not.toHaveBeenCalled();
+  });
+});
+
+describe("warm-start notification navigation", () => {
+  it("navigates when the live listener fires", async () => {
+    let listenerCallback:
+      | ((r: Notifications.NotificationResponse) => void)
+      | null = null;
+    mockAddListener.mockImplementation((cb) => {
+      listenerCallback = cb;
+      return { remove: jest.fn() };
+    });
+
+    render(<RootLayout />);
+    await waitFor(() => expect(mockGetLast).toHaveBeenCalled());
+    expect(mockPush).not.toHaveBeenCalled();
+
+    act(() => {
+      listenerCallback!(makeResponse(NOTIFICATION_IDS.dailyExpenseReminder));
+    });
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/expense-form");
+    });
+  });
+});
+
+describe("notification deduplication", () => {
+  it("navigates only once when both cold-start and live listener fire for the same notification", async () => {
+    const response = makeResponse(NOTIFICATION_IDS.dailyExpenseReminder);
+    mockGetLast.mockResolvedValue(response);
+
+    let listenerCallback:
+      | ((r: Notifications.NotificationResponse) => void)
+      | null = null;
+    mockAddListener.mockImplementation((cb) => {
+      listenerCallback = cb;
+      return { remove: jest.fn() };
+    });
+
+    render(<RootLayout />);
+    await waitFor(() => expect(mockPush).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      listenerCallback!(response);
+    });
+
+    expect(mockPush).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("notification navigation with lock enabled", () => {
+  it("queues navigation and fires after unlock on cold-start", async () => {
+    mockUseBudget.mockReturnValue({
+      isLoaded: true,
+      state: { lockEnabled: true },
+      lockSuppressed: false,
+    });
+    mockGetLast.mockResolvedValue(
+      makeResponse(NOTIFICATION_IDS.dailyExpenseReminder),
+    );
+
+    render(<RootLayout />);
+
+    // Flush all pending microtasks so the promise resolves and
+    // handleResponse sets pendingNavigation — but push must not fire yet
+    await act(async () => {});
+    expect(mockPush).not.toHaveBeenCalled();
+
+    // Simulate user unlocking the app
+    await act(async () => {
+      mockOnUnlock?.();
+    });
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/expense-form");
+    });
   });
 });

--- a/__tests__/notificationNavigation.test.tsx
+++ b/__tests__/notificationNavigation.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Tests for notification deep-linking in app/_layout.tsx.
+ *
+ * Verifies that tapping a notification cold-starts the app and routes to the
+ * correct screen (getLastNotificationResponseAsync path, Android cold-start).
+ */
+import React from "react";
+import { render, waitFor } from "@testing-library/react-native";
+import * as Notifications from "expo-notifications";
+import { NOTIFICATION_IDS } from "@/utils/notifications";
+
+const mockPush = jest.fn();
+
+jest.mock("expo-router", () => {
+  const StackScreen = () => null;
+  const Stack = Object.assign(
+    ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    { Screen: StackScreen },
+  );
+  return {
+    useRouter: () => ({ push: mockPush, back: jest.fn() }),
+    Stack,
+  };
+});
+
+jest.mock("expo-splash-screen", () => ({
+  preventAutoHideAsync: jest.fn().mockResolvedValue(undefined),
+  setOptions: jest.fn(),
+  hideAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@expo-google-fonts/inter", () => ({
+  useFonts: () => [true],
+  Inter_400Regular: undefined,
+  Inter_500Medium: undefined,
+  Inter_600SemiBold: undefined,
+  Inter_700Bold: undefined,
+  Inter_800ExtraBold: undefined,
+}));
+
+jest.mock("@/context/BudgetContext", () => ({
+  useBudget: () => ({
+    isLoaded: true,
+    state: { lockEnabled: false },
+    lockSuppressed: false,
+  }),
+  BudgetProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+jest.mock("@/components/AppName", () => () => null);
+jest.mock("@/components/LockScreen", () => () => null);
+jest.mock("@/utils/crashlytics", () => ({ initCrashlytics: jest.fn() }));
+jest.mock("@/utils/lockTimer", () => ({
+  shouldReLock: jest.fn().mockReturnValue(false),
+}));
+
+import RootLayout from "@/app/_layout";
+
+const mockGetLast =
+  Notifications.getLastNotificationResponseAsync as jest.Mock;
+const mockAddListener =
+  Notifications.addNotificationResponseReceivedListener as jest.Mock;
+
+function makeResponse(id: string): Notifications.NotificationResponse {
+  return {
+    notification: {
+      request: {
+        identifier: id,
+        content: { title: "t", body: "b", data: {} },
+        trigger: {},
+      },
+      date: Date.now(),
+    },
+    actionIdentifier: "com.apple.UNNotificationDefaultActionIdentifier",
+  } as unknown as Notifications.NotificationResponse;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetLast.mockResolvedValue(null);
+  mockAddListener.mockReturnValue({ remove: jest.fn() });
+});
+
+describe("cold-start notification navigation", () => {
+  it("navigates to /expense-form when daily reminder cold-starts the app", async () => {
+    mockGetLast.mockResolvedValue(
+      makeResponse(NOTIFICATION_IDS.dailyExpenseReminder),
+    );
+    render(<RootLayout />);
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/expense-form");
+    });
+  });
+
+  it("navigates to /(tabs)/settings when weekly reminder cold-starts the app", async () => {
+    mockGetLast.mockResolvedValue(
+      makeResponse(NOTIFICATION_IDS.weeklyBackupReminder),
+    );
+    render(<RootLayout />);
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/(tabs)/settings");
+    });
+  });
+
+  it("does not navigate when there is no stored notification response", async () => {
+    mockGetLast.mockResolvedValue(null);
+    render(<RootLayout />);
+    await waitFor(() => expect(mockGetLast).toHaveBeenCalled());
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("does not navigate for an unrecognised notification identifier", async () => {
+    mockGetLast.mockResolvedValue(makeResponse("some-other-notification"));
+    render(<RootLayout />);
+    await waitFor(() => expect(mockGetLast).toHaveBeenCalled());
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -65,24 +65,31 @@ function RootLayoutNav() {
 
   // Handle notification taps — navigate to the relevant screen
   useEffect(() => {
-    const subscription = Notifications.addNotificationResponseReceivedListener(
-      (response) => {
-        const id = response.notification.request.identifier;
-        let destination: string | null = null;
-        if (id === NOTIFICATION_IDS.dailyExpenseReminder) {
-          destination = "/expense-form";
-        } else if (id === NOTIFICATION_IDS.weeklyBackupReminder) {
-          destination = "/(tabs)/settings";
-        }
-        if (!destination) return;
+    function handleResponse(response: Notifications.NotificationResponse) {
+      const id = response.notification.request.identifier;
+      let destination: string | null = null;
+      if (id === NOTIFICATION_IDS.dailyExpenseReminder) {
+        destination = "/expense-form";
+      } else if (id === NOTIFICATION_IDS.weeklyBackupReminder) {
+        destination = "/(tabs)/settings";
+      }
+      if (!destination) return;
 
-        if (isAuthenticatedRef.current) {
-          router.push(destination as Parameters<typeof router.push>[0]);
-        } else {
-          pendingNavigation.current = destination;
-        }
-      },
-    );
+      if (isAuthenticatedRef.current) {
+        router.push(destination as Parameters<typeof router.push>[0]);
+      } else {
+        pendingNavigation.current = destination;
+      }
+    }
+
+    // On Android, tapping a notification that cold-starts the app does not fire
+    // addNotificationResponseReceivedListener. Retrieve the stored response instead.
+    Notifications.getLastNotificationResponseAsync().then((response) => {
+      if (response) handleResponse(response);
+    });
+
+    const subscription =
+      Notifications.addNotificationResponseReceivedListener(handleResponse);
     return () => subscription.remove();
   }, [router]);
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -41,6 +41,7 @@ function RootLayoutNav() {
   const appState = useRef(AppState.currentState);
   const backgroundedAt = useRef<number | null>(null);
   const lockSuppressedRef = useRef(lockSuppressed);
+  const handledNotificationDate = useRef<number | null>(null);
   const LOCK_GRACE_MS = 30_000;
 
   // Keep refs in sync so event handlers always read the latest value
@@ -66,6 +67,12 @@ function RootLayoutNav() {
   // Handle notification taps — navigate to the relevant screen
   useEffect(() => {
     function handleResponse(response: Notifications.NotificationResponse) {
+      // Deduplicate: both getLastNotificationResponseAsync and the live listener
+      // can fire for the same notification on warm starts.
+      const notifDate = response.notification.date;
+      if (handledNotificationDate.current === notifDate) return;
+      handledNotificationDate.current = notifDate;
+
       const id = response.notification.request.identifier;
       let destination: string | null = null;
       if (id === NOTIFICATION_IDS.dailyExpenseReminder) {
@@ -82,15 +89,21 @@ function RootLayoutNav() {
       }
     }
 
+    let cancelled = false;
     // On Android, tapping a notification that cold-starts the app does not fire
     // addNotificationResponseReceivedListener. Retrieve the stored response instead.
-    Notifications.getLastNotificationResponseAsync().then((response) => {
-      if (response) handleResponse(response);
-    });
+    Notifications.getLastNotificationResponseAsync()
+      .then((response) => {
+        if (!cancelled && response) handleResponse(response);
+      })
+      .catch(() => {});
 
     const subscription =
       Notifications.addNotificationResponseReceivedListener(handleResponse);
-    return () => subscription.remove();
+    return () => {
+      cancelled = true;
+      subscription.remove();
+    };
   }, [router]);
 
   // Once data loads, resolve initial auth state


### PR DESCRIPTION
On Android, tapping a notification that cold-starts the app does not trigger `addNotificationResponseReceivedListener`. The fix calls `getLastNotificationResponseAsync()` on mount to retrieve the stored response and navigate to the correct screen.

Closes #1

Generated with [Claude Code](https://claude.ai/code)